### PR TITLE
Added sendAck function

### DIFF
--- a/Adafruit_PN532.cpp
+++ b/Adafruit_PN532.cpp
@@ -1750,6 +1750,17 @@ uint8_t Adafruit_PN532::setDataTarget(uint8_t *cmd, uint8_t cmdlen) {
 
 /**************************************************************************/
 /*!
+    @brief  Sends an ACK to the PN532 causing it to abort the current operation and wait for a new command
+*/
+/**************************************************************************/
+bool Adafruit_PN532::sendAck() {
+  uint8_t cmd = PN532_SPI_DATAWRITE;
+  spi_dev->write(pn532ack, 6, &cmd, 1);
+  return true;
+}
+
+/**************************************************************************/
+/*!
     @brief  Writes a command to the PN532, automatically inserting the
             preamble and required frame details (checksum, len, etc.)
 

--- a/Adafruit_PN532.h
+++ b/Adafruit_PN532.h
@@ -167,6 +167,7 @@ public:
   bool writeGPIO(uint8_t pinstate);
   uint8_t readGPIO(void);
   bool setPassiveActivationRetries(uint8_t maxRetries);
+  bool sendAck();
 
   // ISO14443A functions
   bool readPassiveTargetID(


### PR DESCRIPTION
Sends an ACK to the PN532 causing it to abort the current operation and wait for a new command

https://github.com/adafruit/Adafruit-PN532/issues/85
